### PR TITLE
Strip forwarded headers from incoming requests

### DIFF
--- a/salt/profiles/config/etc-nginx-sites-enabled-profiles.conf
+++ b/salt/profiles/config/etc-nginx-sites-enabled-profiles.conf
@@ -17,6 +17,7 @@ server {
         include /etc/uwsgi/params;
         uwsgi_param HTTP_HOST {{ pillar.profiles.default_host }};
         uwsgi_param UWSGI_SCHEME {{ pillar.profiles.default_scheme }};
+        uwsgi_param HTTP_X_FORWARDED_PROTO '';
     }
 
     access_log /var/log/nginx/profiles.access.log combined_with_time;

--- a/salt/profiles/config/etc-nginx-sites-enabled-profiles.conf
+++ b/salt/profiles/config/etc-nginx-sites-enabled-profiles.conf
@@ -17,6 +17,12 @@ server {
         include /etc/uwsgi/params;
         uwsgi_param HTTP_HOST {{ pillar.profiles.default_host }};
         uwsgi_param UWSGI_SCHEME {{ pillar.profiles.default_scheme }};
+
+        # Remove knowledge of proxies
+        uwsgi_param HTTP_FORWARDED '';
+        uwsgi_param HTTP_X_FORWARDED_FOR '';
+        uwsgi_param HTTP_X_FORWARDED_HOST '';
+        uwsgi_param HTTP_X_FORWARDED_PORT '';
         uwsgi_param HTTP_X_FORWARDED_PROTO '';
     }
 


### PR DESCRIPTION
This header is trusted by uwsgi by default
https://github.com/unbit/uwsgi/blob/2.0.15/core/protocol.c#L530
and it shouldn't. Rely on UWSGI_SCHEME instead