### PR TITLE
Multiple uWSGI workers

### DIFF
--- a/salt/profiles/config/srv-profiles-uwsgi.ini
+++ b/salt/profiles/config/srv-profiles-uwsgi.ini
@@ -9,9 +9,9 @@ callable = APP
 
 socket = /tmp/profiles-uwsgi.sock
 logto = /var/log/uwsgi.log
-master=True
 chmod-socket = 666
-processes=1
+master=True
+processes=4
 vacuum=True
 max-requests=5000
 


### PR DESCRIPTION
Slightly better availability by answering requests with other workers when one has a corrupted state.

Not useful if broken workers are not reaped.