### PR TITLE
Fix pythonpath typo

### DIFF
--- a/salt/profiles/config/srv-profiles-uwsgi.ini
+++ b/salt/profiles/config/srv-profiles-uwsgi.ini
@@ -2,7 +2,6 @@
 chdir=/srv/profiles/
 uid={{ pillar.elife.webserver.username }}
 gid={{ pillar.elife.webserver.username }}
-pythonpath=/srv/profiles/
 virtualenv=/srv/profiles/venv/
 wsgi-file = manage.py 
 callable = APP

--- a/salt/profiles/config/srv-profiles-uwsgi.ini
+++ b/salt/profiles/config/srv-profiles-uwsgi.ini
@@ -2,7 +2,7 @@
 chdir=/srv/profiles/
 uid={{ pillar.elife.webserver.username }}
 gid={{ pillar.elife.webserver.username }}
-pythonpath=/srv/profile/
+pythonpath=/srv/profiles/
 virtualenv=/srv/profiles/venv/
 wsgi-file = manage.py 
 callable = APP


### PR DESCRIPTION
This is probably not used, or we would have found out sooner?