### PR TITLE
Validate X-Consumer-Groups comes from api-gateway

### DIFF
--- a/salt/pillar/profiles.sls
+++ b/salt/pillar/profiles.sls
@@ -30,6 +30,10 @@ profiles:
         subscriber: null
         region: us-east-1
         # TODO: add optional goaws endpoint_url
+    consumer_groups_filter:
+        api_gateway:
+            username: api-gateway
+            password: some-credentials
 
 elife:
     aws:

--- a/salt/profiles/config/etc-nginx-sites-enabled-profiles.conf
+++ b/salt/profiles/config/etc-nginx-sites-enabled-profiles.conf
@@ -1,8 +1,14 @@
+{% from 'elife/nginx-macros.sls' import consumer_groups_filter %}
+{{ consumer_groups_filter(pillar.profiles.consumer_groups_filter) }}
+
 server {
     listen 80;
     listen 443 ssl;
 
     server_name localhost;
+
+    # authentication debugging
+    add_header "X-Consumer-Groups-Filtered" $consumer_groups_filtered;
 
     location = /favicon.ico { access_log off; log_not_found off; }
     location = /robots.txt { access_log off; log_not_found off; }
@@ -13,6 +19,7 @@ server {
         include /etc/uwsgi/params;
         uwsgi_param HTTP_HOST {{ pillar.profiles.default_host }};
         uwsgi_param UWSGI_SCHEME {{ pillar.profiles.default_scheme }};
+        uwsgi_param HTTP_X_CONSUMER_GROUPS $consumer_groups_filtered;
 
         # Remove knowledge of proxies
         uwsgi_param HTTP_FORWARDED '';


### PR DESCRIPTION
Replicates the same pattern in use in `lax` and `journal-cms`. Happy to explain how it works.