### PR TITLE
salt 2019.2 upgrade

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-elifeFormula('profiles', '/srv/profiles', null, ['s1804'])
+elifeFormula('profiles', '/srv/profiles', null, ['snsalt'])


### PR DESCRIPTION
jenkinsfile, replaces 1804 build with a next-salt build
1804 build is now default for this project.