### PR TITLE
nginx, docker upstream 

### DIFF
--- a/salt/profiles/config/etc-nginx-sites-enabled-profiles.conf
+++ b/salt/profiles/config/etc-nginx-sites-enabled-profiles.conf
@@ -7,7 +7,11 @@ upstream docker {
     # see:
     # - https://nginx.org/en/docs/http/ngx_http_upstream_module.html#max_fails
     # - https://nginx.org/en/docs/http/ngx_http_upstream_module.html#fail_timeout
+
+    # lsh@2021-01-15: 'localhost' is occasionally resolved to the ipv6 '::1', however profiles is
+    # listening on the ipv4 '127.0.0.1'. It's easier to pin 127.0.0.1 here than update profiles.
     #server localhost:9000 max_fails=0;
+
     server 127.0.0.1:9000 max_fails=0;
 }
 

--- a/salt/profiles/config/etc-nginx-sites-enabled-profiles.conf
+++ b/salt/profiles/config/etc-nginx-sites-enabled-profiles.conf
@@ -1,6 +1,16 @@
 {% from 'elife/nginx-macros.sls' import consumer_groups_filter %}
 {{ consumer_groups_filter(pillar.profiles.consumer_groups_filter) }}
 
+upstream docker {
+    # 'max_fails=1' (default) will disable the upstream for 'fail_timeout=10' seconds (default)
+    # 'max_fails=0' disables the number of failed attempts to consider before upstream is marked as unavailable for 10 seconds.
+    # see:
+    # - https://nginx.org/en/docs/http/ngx_http_upstream_module.html#max_fails
+    # - https://nginx.org/en/docs/http/ngx_http_upstream_module.html#fail_timeout
+    #server localhost:9000 max_fails=0;
+    server 127.0.0.1:9000 max_fails=0;
+}
+
 server {
     listen 80;
     listen 443 ssl;
@@ -14,7 +24,7 @@ server {
     location = /robots.txt { access_log off; log_not_found off; }
 
     location / {
-        uwsgi_pass localhost:9000;
+        uwsgi_pass docker;
         # WARNING: this value *must* be higher than uwsgi's 'harakiri' value (10s) in /srv/profiles/uwsgi.ini
         uwsgi_read_timeout 11s;
         include /etc/uwsgi/params;


### PR DESCRIPTION
* nginx, `fail_timeout` disabled with `max_fails=0`
* nginx, switched to ipv4 '127.0.0.1' rather than 'localhost' that would occasionally be resolved to '::1' and emit a 'connection failed' error into the logs (but still succeed)