### PR TITLE
increase timeout

### DIFF
--- a/salt/profiles/config/etc-nginx-sites-enabled-profiles.conf
+++ b/salt/profiles/config/etc-nginx-sites-enabled-profiles.conf
@@ -30,7 +30,7 @@ server {
     location / {
         uwsgi_pass docker;
         # WARNING: this value *must* be higher than uwsgi's 'harakiri' value (10s) in /srv/profiles/uwsgi.ini
-        uwsgi_read_timeout 11s;
+        uwsgi_read_timeout 21s;
         include /etc/uwsgi/params;
         uwsgi_param HTTP_HOST {{ pillar.profiles.default_host }};
         uwsgi_param UWSGI_SCHEME {{ pillar.profiles.default_scheme }};

--- a/salt/profiles/config/srv-profiles-uwsgi.ini
+++ b/salt/profiles/config/srv-profiles-uwsgi.ini
@@ -10,13 +10,13 @@ socket = 0.0.0.0:9000
 logto = /srv/profiles/var/logs/uwsgi.log
 master=True
 # aka workers
-processes=8
+processes=12
 vacuum=True
 max-requests=5000
 
 # kill self after this many seconds
 # this value *must* be less than the nginx timeout
-harakiri = 10
+harakiri = 20
 # documented at https://docs.newrelic.com/docs/agents/python-agent/hosting-mechanisms/python-agent-uwsgi
 single-interpreter = True
 enable-threads = True


### PR DESCRIPTION
* nginx, increases timeout again to 20seconds.
* increases workers to 12 from 8

getting loads more of 

```
2021/01/15 00:11:02 [error] 11515#11515: *306 upstream timed out (110: Connection timed out) while reading response header from upstream, client: 104.130.135.185, server: localhost, request: "POST /orcid-webhook/IjAwMDAtMDAw....xVXwF9_bJiVFGw_cbzT_6UPWRd-bQ2saoHa4HLBaxShA HTTP/1.1", upstream: "uwsgi://127.0.0.1:9000", host: "prod--profiles.elifesciences.org"
2021/01/15 00:11:02 [error] 11515#11515: *313 upstream timed out (110: Connection timed out) while reading response header from upstream, client: 104.130.135.185, server: localhost, request: "POST /orcid-webhook/IjAwMDAtMDA...ndEMSyIpqvoodum1m_f1VIyGK-8Z5TU6LxwCk4BSyOhQ HTTP/1.1", upstream: "uwsgi://127.0.0.1:9000", host: "prod--profiles.elifesciences.org"
```